### PR TITLE
Remove unnecessary usage of app_ctx_stack

### DIFF
--- a/flask_sqlalchemy_session/__init__.py
+++ b/flask_sqlalchemy_session/__init__.py
@@ -8,7 +8,7 @@ unique sessions per Flask request
 """
 # pylint: disable=invalid-name
 from werkzeug.local import LocalProxy
-from flask import _app_ctx_stack, current_app
+from flask import current_app
 from sqlalchemy.orm import scoped_session
 
 __all__ = ["current_session", "flask_scoped_session"]
@@ -17,11 +17,6 @@ __version__ = 1.1
 
 def _get_session():
     # pylint: disable=missing-docstring, protected-access
-    context = _app_ctx_stack.top
-    if context is None:
-        raise RuntimeError(
-            "Cannot access current_session when outside of an application "
-            "context.")
     app = current_app._get_current_object()
     if not hasattr(app, "scoped_session"):
         raise AttributeError(


### PR DESCRIPTION
This was only used to check if the application context exists, and if it didn't exist an exception was raised with an explanatory message.

Trying to access current_app._get_current_object() raises the same kind of exception with an equivalent explanatory message, therefore the usage of app_ctx_stack and the check around it was completely redundant.

Fixes issue #16
Requires PR https://github.com/dtheodor/flask-sqlalchemy-session/pull/15